### PR TITLE
Protect against non-character weirdness with tags and labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # bs4cards 0.1.1
 
+* Fixed an internal error when tags and labels aren't used with the cards
+  (thanks @sciencificity #31, @gadenbuie #38).
 * `label_colour` and `border_colour` now default to NULL (inherit from parent)
 * Added bslib as a suggested package. 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/build-tag-list.R
+++ b/R/build-tag-list.R
@@ -1,7 +1,7 @@
 
 
 build_tag_list <- function(tags) {
-  if(is_na(tags[[1]])) return(NULL)
+  if(is_null(tags) || is_na(tags[[1]])) return(NULL)
   categories <- unique_tags(tags)
   if(length(categories) == 0) return(NULL)
   labels <- unique_labels(tags)
@@ -12,7 +12,8 @@ build_tag_list <- function(tags) {
 }
 
 unique_labels <- function(x) {
-  s <- unlist(strsplit(x, split = ";"))
+  if (is_null(x) || is_na(x)) return(character())
+  s <- unlist(strsplit(as.character(x), split = ";"))
   s <- gsub("^[[:space:]]+", "", s)
   s <- gsub("[[:space:]]+$", "", s)
   s <- unique(s)
@@ -20,8 +21,9 @@ unique_labels <- function(x) {
 }
 
 unique_tags <- function(x) {
+  if (is_null(x) || is_na(x)) return(character())
   #unique(unlist(strsplit(x, split = "[[:space:]]+")))
-  s <- unlist(strsplit(x, split = ";"))
+  s <- unlist(strsplit(as.character(x), split = ";"))
   s <- gsub("^[[:space:]]+", "", s)
   s <- gsub("[[:space:]]+$", "", s)
   s <- gsub("[[:space:]]+", "-", s)


### PR DESCRIPTION
This PR fixes #31, which I believe was caused primarily by `strsplit(x, ';')` having a hard time when `x` is a factor.

I added `as.character(x)` to make sure that `strsplit()` is operating on a character vector, after discarding obvious no-op cases like `NULL` and `NA`.
